### PR TITLE
Add docs alias for RTFM command

### DIFF
--- a/sopel_rtfm/__init__.py
+++ b/sopel_rtfm/__init__.py
@@ -113,7 +113,7 @@ def shutdown(bot):
             pass
 
 
-@module.commands('rtfm')
+@module.commands('rtfm', 'docs')
 @module.example('.rtfm bind_host')
 @module.output_prefix('[rtfm] ')
 def suggest_doc_link(bot, trigger):


### PR DESCRIPTION
Tin. I find myself shying away from using the `.rtfm` command when it would be useful because the acronym scans as fairly rude to me. I would love to have an alias for it :D